### PR TITLE
修复了在爬取早期数据的时候无法正确处理郑商所代码的问题

### DIFF
--- a/fushare/basis.py
+++ b/fushare/basis.py
@@ -80,7 +80,7 @@ def get_spotPrice(date = None,vars = cons.vars):
                 domBasisRate    主力合约相对现货的基差率       float
                 date            日期                       string YYYYMMDD
     """
-	
+
     date = cons.convert_date(date) if date is not None else datetime.date.today()
     u1 = cons.SYS_SPOTPRICE_LATEST_URL
     u2 = cons.SYS_SPOTPRICE_URL %date.strftime('%Y-%m-%d')
@@ -125,8 +125,10 @@ def _check_information(df, date):
             records = records.append(record)
 
 
-    records.loc[:, ['nearPrice', 'domPrice', 'SP']] = records.loc[:, ['nearPrice', 'domPrice', 'SP']].astype(
-        'float')
+    records.loc[:, ['nearPrice', 'domPrice', 'SP']] = records.loc[:, ['nearPrice', 'domPrice', 'SP']].astype('float')
+
+    records.loc[:,'nearSymbol'] = records['nearSymbol'].replace('[A-Za-z]*(\d*)', '\g<1>',regex=True)
+    records.loc[:,'domSymbol'] = records['domSymbol'].replace('[A-Za-z]*(\d*)', '\g<1>',regex=True)
 
     records.loc[:, 'nearSymbol'] = records['var'] + records.loc[:, 'nearSymbol'].astype('int').astype('str')
     records.loc[:, 'domSymbol'] = records['var'] + records.loc[:, 'domSymbol'].astype('int').astype('str')

--- a/fushare/basis.py
+++ b/fushare/basis.py
@@ -127,8 +127,8 @@ def _check_information(df, date):
 
     records.loc[:, ['nearPrice', 'domPrice', 'SP']] = records.loc[:, ['nearPrice', 'domPrice', 'SP']].astype('float')
 
-    records.loc[:,'nearSymbol'] = records['nearSymbol'].replace('[A-Za-z]*(\d*)', '\g<1>',regex=True)
-    records.loc[:,'domSymbol'] = records['domSymbol'].replace('[A-Za-z]*(\d*)', '\g<1>',regex=True)
+    records.loc[:,'nearSymbol'] = records['nearSymbol'].replace('[^0-9]*(\d*)$', '\g<1>',regex=True)
+    records.loc[:,'domSymbol'] = records['domSymbol'].replace('[^0-9]*(\d*)$', '\g<1>',regex=True)
 
     records.loc[:, 'nearSymbol'] = records['var'] + records.loc[:, 'nearSymbol'].astype('int').astype('str')
     records.loc[:, 'domSymbol'] = records['var'] + records.loc[:, 'domSymbol'].astype('int').astype('str')


### PR DESCRIPTION
在爬取早期的数据的时候因为郑商所主力合约和连续合约为CF101样式，程序处理时会直接跳到exception从而导致今天没有数据的假象，添加了两行正则表达式替换的语句后，将CF101替换为了101，可以正确爬取数据不报错